### PR TITLE
Reduce size of image layer by using optimal gzip compression

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,7 +102,7 @@ HOME_URL="https://wolfi.dev"
 
 	l, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {
 		return io.NopCloser(bytes.NewReader(buf.Bytes())), nil
-	})
+	}, tarball.WithCompressionLevel(gzip.BestCompression))
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
The default compression from `tarball.LayerFromOpener` is `gzip.BestSpeed`: https://github.com/google/go-containerregistry/blob/8b3c3036d612bcb3c1147fe11c2d1818dc432329/pkg/v1/tarball/layer.go#L239

We can reduce the size of the layer tarball from `351078` bytes to `268425` bytes (just over 3/4 of the original size) by using `gzip.BestCompression` instead.