### PR TITLE
Improve compressed size by grouping/sorting packages and versions

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"archive/tar"
-	"bufio"
 	"bytes"
-	"compress/gzip"
+	"encoding/json"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"os"
-	"strings"
+	"sort"
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/name"
@@ -26,58 +25,62 @@ func main() {
 		dst = os.Args[1]
 	}
 
-	ir, err := http.Get("https://packages.wolfi.dev/os/x86_64/APKINDEX.tar.gz")
+	ir, err := http.Get("https://packages.wolfi.dev/os/x86_64/APKINDEX.json")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer ir.Body.Close()
+	body, err := io.ReadAll(ir.Body)
 	if err != nil {
 		log.Fatal(err)
 	}
 	if ir.StatusCode != 200 {
 		log.Fatal(ir.StatusCode)
 	}
-	defer ir.Body.Close()
+
+	var index struct {
+		Packages []struct {
+			Name    string
+			Version string
+			Origin  string
+		}
+	}
+	if err := json.Unmarshal(body, &index); err != nil {
+		log.Fatal(err)
+	}
+
+	sort.Slice(index.Packages, func(idx, jdx int) bool {
+		if index.Packages[idx].Name == index.Packages[jdx].Name {
+			return index.Packages[idx].Version < index.Packages[jdx].Version
+		}
+		return index.Packages[idx].Name < index.Packages[jdx].Name
+	})
 
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	gr, err := gzip.NewReader(ir.Body)
-	if err != nil {
+	var minimalAPKDB bytes.Buffer
+	for _, pkg := range index.Packages {
+		minimalAPKDB.WriteString("P:" + pkg.Name + "\n")
+		minimalAPKDB.WriteString("V:" + pkg.Version + "\n")
+		if pkg.Origin != "" {
+			minimalAPKDB.WriteString("o:" + pkg.Origin + "\n")
+		}
+		minimalAPKDB.WriteString("\n")
+	}
+
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "lib/apk/db/installed",
+		Size: int64(minimalAPKDB.Len()),
+		Mode: 0644,
+	}); err != nil {
 		log.Fatal(err)
 	}
-	defer gr.Close()
-	tr := tar.NewReader(gr)
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			log.Fatal("found no APKINDEX")
-		}
-		if err != nil {
-			log.Fatal(err)
-		}
-		if hdr.Name == "APKINDEX" {
-			hdr.Name = "lib/apk/db/installed"
-
-			var minimalAPKDB bytes.Buffer
-			scanner := bufio.NewScanner(tr)
-			for scanner.Scan() {
-				line := scanner.Text()
-				if strings.HasPrefix(line, "P:") || strings.HasPrefix(line, "V:") || strings.HasPrefix(line, "o:") || line == "" {
-					minimalAPKDB.WriteString(line + "\n")
-				}
-			}
-			if err := scanner.Err(); err != nil {
-				log.Fatal(err)
-			}
-
-			hdr.Size = int64(minimalAPKDB.Len())
-			if err := tw.WriteHeader(hdr); err != nil {
-				log.Fatal(err)
-			}
-			if _, err := tw.Write(minimalAPKDB.Bytes()); err != nil {
-				log.Fatal(err)
-			}
-			log.Println("wrote /lib/apk/db/installed")
-			break
-		}
+	if _, err := tw.Write(minimalAPKDB.Bytes()); err != nil {
+		log.Fatal(err)
 	}
+	log.Println("wrote /lib/apk/db/installed")
+
 	osRelease := `ID=wolfi
 NAME="Wolfi"
 PRETTY_NAME="Wolfi"


### PR DESCRIPTION
We can improve the compressed size of the final layer by sorting the list of packages and versions so that gzip has the best chance of finding similar strings in a given compression window. 

Because the current implementation filters `APKINDEX.tar.gz` as it is read/downloaded which is not conducive to sorting, I switched to instead use the Wolfi specific `APKINDEX.json` file to obtain a list of all packages/versions. I'm not sure if these files are 1:1 equivalent though since just making this change reduced the compressed size from `351107` bytes to `310873` bytes.

In my testing this reduces the compressed layer size from `351078` bytes to `218255` bytes. When adding the compression change from #3, we can get all the way down to `158438` bytes, 45% of the original/current layer size!